### PR TITLE
Change pbi to png in appinfo.json

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -31,12 +31,12 @@
         "file": "images/confirm.png"
       },
       {
-        "type": "pbi",
+        "type": "png",
         "name": "CROSS",
         "file": "images/cross.png"
       },
       {
-        "type": "pbi",
+        "type": "png",
         "name": "TICK",
         "file": "images/tick.png"
       },


### PR DESCRIPTION
This fixes problems with building this project in CloudPebble. The choice dialog still shows correctly on Basalt.

As part of testing, I tried building for Aplite by modifying the project settings, but there's some color and API references that prevent that from working right now.
